### PR TITLE
Prevent NaN result in the Kaiser window function

### DIFF
--- a/dsp/windows.h
+++ b/dsp/windows.h
@@ -157,12 +157,9 @@ kaiser (sample_t * s, int n, double beta, double step = 1)
 
 	for (double i = -n / 2 + .1; si < n; ++si, i += step)
 	{
-		double k = besseli ((beta * sqrt (1 - pow ((2 * i / (n - 1)), 2)))) / bb;
-
-		/* can you spell hack */
-		if (!finite (k) || isnan(k))
-			k = 0;
-
+		double a = 1 - pow ((2 * i / (n - 1)), 2);
+		a = (a < 0.0) ? 0.0 : a;
+		double k = besseli ((beta * sqrt (a))) / bb;
 		F (s[si], k);
 	}
 }


### PR DESCRIPTION
This checks for a negative argument passed to `sqrt` in kaiser window code.
This fixes multiple plugins which use oversampling, and results in NaN in their output (AmpVTS, Saturate, ...)
Normally, a call of `isnan` which follows must fix the result in order to be 0.
That check is not working as intended, as an unfortunate result of `-ffast-math` compiler flags (which implies `-ffinite-math-only`).