### PR TITLE
Use standard exp10f instead of pow10f

### DIFF
--- a/dsp/v4f_IIR2.h
+++ b/dsp/v4f_IIR2.h
@@ -33,7 +33,7 @@
 namespace DSP {
 
 #ifdef __APPLE__
-inline float pow10f(float f) {return pow(10,f);}
+inline float exp10f(float f) {return pow(10,f);}
 #endif
 
 class RBJv4
@@ -142,7 +142,7 @@ class IIR2v4
 				/* A = pow (10, gain / 40) */
 				v4f_t A = (v4f_t) {.025,.025,.025,.025};
 				A *= gain;
-				A = v4f_map<pow10f> (A);
+				A = v4f_map<exp10f> (A);
 
 				RBJv4 p (f, Q);
 
@@ -429,7 +429,7 @@ class IIR2v4Bank
 					/* A = pow (10, gain / 40) */
 					v4f_t A = (v4f_t) {.025,.025,.025,.025};
 					A *= gain[i];
-					A = v4f_map<pow10f> (A);
+					A = v4f_map<exp10f> (A);
 
 					RBJv4 p (f[i], Q[i]);
 


### PR DESCRIPTION
Link to [Debian patch](https://salsa.debian.org/multimedia-team/caps/commit/a411203d6390456a2ea62e1628528fb6b6c1e72a) by Aurelien Jarno, made for original Caps plugins
This fixes the build on recent glibc versions, which don't have a declaration of the obsolete function `pow10f`.
