### PR TITLE
Honour $PREFIX and $LV2DIR if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXXFLAGS += `pkg-config --cflags lv2`
@@ -65,7 +66,7 @@ install: all
 	$(MAKE) install -C plugins/mod-caps-Wider.lv2
 
 uninstall:
-	-rm -rf $(DESTDIR)$(PREFIX)/lib/lv2/mod-caps-*.lv2/
+	-rm -rf $(DESTDIR)$(LV2DIR)/mod-caps-*.lv2/
 
 clean:
 	rm -f *.o dsp/*.o

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
-PREFIX = /usr
+PREFIX ?= /usr/local
 DESTDIR =
+
+CXXFLAGS += `pkg-config --cflags lv2`
 
 all: build
 

--- a/Makefile.single
+++ b/Makefile.single
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/Makefile.single
+++ b/Makefile.single
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = __EFFECT__
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-AmpVTS.lv2/Makefile
+++ b/plugins/mod-caps-AmpVTS.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-AmpVTS.lv2/Makefile
+++ b/plugins/mod-caps-AmpVTS.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = AmpVTS
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-AutoFilter.lv2/Makefile
+++ b/plugins/mod-caps-AutoFilter.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-AutoFilter.lv2/Makefile
+++ b/plugins/mod-caps-AutoFilter.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = AutoFilter
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-CEO.lv2/Makefile
+++ b/plugins/mod-caps-CEO.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-CEO.lv2/Makefile
+++ b/plugins/mod-caps-CEO.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = CEO
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-CabinetIII.lv2/Makefile
+++ b/plugins/mod-caps-CabinetIII.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = CabinetIII
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-CabinetIII.lv2/Makefile
+++ b/plugins/mod-caps-CabinetIII.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-CabinetIV.lv2/Makefile
+++ b/plugins/mod-caps-CabinetIV.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-CabinetIV.lv2/Makefile
+++ b/plugins/mod-caps-CabinetIV.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = CabinetIV
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-ChorusI.lv2/Makefile
+++ b/plugins/mod-caps-ChorusI.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-ChorusI.lv2/Makefile
+++ b/plugins/mod-caps-ChorusI.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = ChorusI
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Click.lv2/Makefile
+++ b/plugins/mod-caps-Click.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Click.lv2/Makefile
+++ b/plugins/mod-caps-Click.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Click
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Compress.lv2/Makefile
+++ b/plugins/mod-caps-Compress.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Compress.lv2/Makefile
+++ b/plugins/mod-caps-Compress.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Compress
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-CompressX2.lv2/Makefile
+++ b/plugins/mod-caps-CompressX2.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-CompressX2.lv2/Makefile
+++ b/plugins/mod-caps-CompressX2.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = CompressX2
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Eq10.lv2/Makefile
+++ b/plugins/mod-caps-Eq10.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Eq10.lv2/Makefile
+++ b/plugins/mod-caps-Eq10.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Eq10
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Eq10X2.lv2/Makefile
+++ b/plugins/mod-caps-Eq10X2.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Eq10X2.lv2/Makefile
+++ b/plugins/mod-caps-Eq10X2.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Eq10X2
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Eq4p.lv2/Makefile
+++ b/plugins/mod-caps-Eq4p.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Eq4p.lv2/Makefile
+++ b/plugins/mod-caps-Eq4p.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Eq4p
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-EqFA4p.lv2/Makefile
+++ b/plugins/mod-caps-EqFA4p.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-EqFA4p.lv2/Makefile
+++ b/plugins/mod-caps-EqFA4p.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = EqFA4p
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Fractal.lv2/Makefile
+++ b/plugins/mod-caps-Fractal.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Fractal.lv2/Makefile
+++ b/plugins/mod-caps-Fractal.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Fractal
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Narrower.lv2/Makefile
+++ b/plugins/mod-caps-Narrower.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Narrower
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Narrower.lv2/Makefile
+++ b/plugins/mod-caps-Narrower.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Noisegate.lv2/Makefile
+++ b/plugins/mod-caps-Noisegate.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Noisegate.lv2/Makefile
+++ b/plugins/mod-caps-Noisegate.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Noisegate
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-PhaserII.lv2/Makefile
+++ b/plugins/mod-caps-PhaserII.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-PhaserII.lv2/Makefile
+++ b/plugins/mod-caps-PhaserII.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = PhaserII
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Plate.lv2/Makefile
+++ b/plugins/mod-caps-Plate.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Plate.lv2/Makefile
+++ b/plugins/mod-caps-Plate.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Plate
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-PlateX2.lv2/Makefile
+++ b/plugins/mod-caps-PlateX2.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = PlateX2
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-PlateX2.lv2/Makefile
+++ b/plugins/mod-caps-PlateX2.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Saturate.lv2/Makefile
+++ b/plugins/mod-caps-Saturate.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Saturate
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Saturate.lv2/Makefile
+++ b/plugins/mod-caps-Saturate.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Scape.lv2/Makefile
+++ b/plugins/mod-caps-Scape.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Scape
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Scape.lv2/Makefile
+++ b/plugins/mod-caps-Scape.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Sin.lv2/Makefile
+++ b/plugins/mod-caps-Sin.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Sin
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Sin.lv2/Makefile
+++ b/plugins/mod-caps-Sin.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Spice.lv2/Makefile
+++ b/plugins/mod-caps-Spice.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Spice.lv2/Makefile
+++ b/plugins/mod-caps-Spice.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Spice
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-SpiceX2.lv2/Makefile
+++ b/plugins/mod-caps-SpiceX2.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-SpiceX2.lv2/Makefile
+++ b/plugins/mod-caps-SpiceX2.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = SpiceX2
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-ToneStack.lv2/Makefile
+++ b/plugins/mod-caps-ToneStack.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-ToneStack.lv2/Makefile
+++ b/plugins/mod-caps-ToneStack.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = ToneStack
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-White.lv2/Makefile
+++ b/plugins/mod-caps-White.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = White
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-White.lv2/Makefile
+++ b/plugins/mod-caps-White.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++

--- a/plugins/mod-caps-Wider.lv2/Makefile
+++ b/plugins/mod-caps-Wider.lv2/Makefile
@@ -1,6 +1,7 @@
 VERSION = 0.9.26
 
 PREFIX ?= /usr/local
+LV2DIR ?= $(PREFIX)/lib/lv2
 DESTDIR =
 
 CXX ?= g++
@@ -30,7 +31,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 PLUG   = Wider
 BUNDLE = mod-caps-$(PLUG).lv2
 ifndef LV2_DEST
-LV2DEST = $(PREFIX)/lib/lv2/$(BUNDLE)
+LV2DEST = $(LV2DIR)/$(BUNDLE)
 else
 LV2DEST = $(LV2_DEST)/$(BUNDLE)
 endif

--- a/plugins/mod-caps-Wider.lv2/Makefile
+++ b/plugins/mod-caps-Wider.lv2/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.9.26
 
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 DESTDIR =
 
 CXX ?= g++


### PR DESCRIPTION
- also get the CXXFLAGS for lv2 using pkg-config


This is needed to build with a prefix. The default remain the same, but if you do `make PREFIX=/some/prefix` it will use `/some/prefix` as a prefix.

Update: also honour `$LV2DIR`