### PR TITLE
Fix memory leak

### DIFF
--- a/Descriptor.h
+++ b/Descriptor.h
@@ -72,7 +72,7 @@ class DescriptorStub
 				URI = 0;
 			}
 
-		~DescriptorStub()
+		virtual ~DescriptorStub()
 			{
 				if (PortCount)
 				{


### PR DESCRIPTION
In interface.cc, an array of Descriptor objects is dynamically created and then later destroyed by calling delete on pointers to the base class DescriptorStub. However, since DescriptorStub's destructor is non-virtual, the destructors of derived classes are not called and this causes a memory leak which I detected with AddressSanitizer:

```
==1814137==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x60e0001424a0 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   160 bytes;
  size of the deallocated type: 152 bytes.
    #0 0x7f15d641822f in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x7f15c5510d3c in caps_so_fini /home/dalton/Documents/lmms_dev2/plugins/LadspaEffect/caps/interface.cc:132
    #2 0x7f15d6d6e24d in _dl_fini elf/dl-fini.c:142
    #3 0x7f15d370a494 in __run_exit_handlers stdlib/exit.c:113
    #4 0x7f15d370a60f in __GI_exit stdlib/exit.c:143
    #5 0x7f15d36eed96 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:74
    #6 0x7f15d36eee3f in __libc_start_main_impl ../csu/libc-start.c:392
    #7 0x55982aedfc34 in _start (/home/dalton/Documents/lmms_dev2/build/lmms+0x798c34)

0x60e0001424a0 is located 0 bytes inside of 160-byte region [0x60e0001424a0,0x60e000142540)
allocated by thread T0 here:
    #0 0x7f15d64171c7 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7f15c55110a4 in caps_so_init /home/dalton/Documents/lmms_dev2/plugins/LadspaEffect/caps/interface.cc:77

SUMMARY: AddressSanitizer: new-delete-type-mismatch ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172 in operator delete(void*, unsigned long)
==1814137==HINT: if you don't care about these errors you may set ASAN_OPTIONS=new_delete_type_mismatch=0
==1814137==ABORTING
```

This PR fixes the problem by making DescriptorStub's destructor virtual.